### PR TITLE
Fix deprecated Light to LightEntity

### DIFF
--- a/custom_components/philips_ambilight/light.py
+++ b/custom_components/philips_ambilight/light.py
@@ -1,4 +1,4 @@
-### Home Assistant Platform to integrate Phillip TVs' Ambilight as a Light Component using the JointSpace API ###
+### Home Assistant Platform to integrate Phillip TVs' Ambilight as a light entity using the JointSpace API ###
 
 
 import json
@@ -6,7 +6,7 @@ import string
 import requests
 import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
-from homeassistant.components.light import (ATTR_BRIGHTNESS, Light, PLATFORM_SCHEMA, ATTR_HS_COLOR,
+from homeassistant.components.light import (ATTR_BRIGHTNESS, LightEntity, PLATFORM_SCHEMA, ATTR_HS_COLOR,
                                             SUPPORT_BRIGHTNESS, SUPPORT_COLOR, ATTR_EFFECT, SUPPORT_EFFECT)
 from homeassistant.const import (CONF_HOST, CONF_NAME, CONF_USERNAME, CONF_PASSWORD)
 from requests.auth import HTTPDigestAuth
@@ -64,7 +64,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
 OLD_STATE = [DEFAULT_HUE, DEFAULT_SATURATION, DEFAULT_BRIGHTNESS, DEFAULT_EFFECT]
 
-class Ambilight(Light):
+class Ambilight(LightEntity):
 
     def __init__(self, name, host, user, password):
         self._name = name


### PR DESCRIPTION
Fix #11

Annonced here : https://developers.home-assistant.io/blog/2020/05/14/entity-class-names/